### PR TITLE
Handle missing DFP custom targeting key

### DIFF
--- a/dfp/get_custom_targeting.py
+++ b/dfp/get_custom_targeting.py
@@ -37,11 +37,11 @@ def get_key_id_by_name(name):
   response = custom_targeting_service.getCustomTargetingKeysByStatement(
       targeting_key_statement.ToStatement())
 
-  key = None
-  if 'results' in response:
-    key = response['results'][0]
+  key_id = None
+  if 'results' in response and len(response['results']) > 0:
+    key_id = response['results'][0]['id']
 
-  return key['id']
+  return key_id
 
 
 def get_targeting_by_key_name(name):

--- a/tests/test_dfp_get_custom_targeting.py
+++ b/tests/test_dfp_get_custom_targeting.py
@@ -139,3 +139,22 @@ class DFPGetCustomTargetingTests(TestCase):
     response = dfp.get_custom_targeting.get_key_id_by_name('hb_pb')
 
     self.assertEqual(response, 987654)
+
+  def test_get_key_id_by_name_no_key(self, mock_dfp_client):
+    """
+    Ensure it returns None when the key does not exist.
+    """
+    mock_dfp_client.return_value = MagicMock()
+
+    # Mock response from DFP for key fetching.
+    (mock_dfp_client.return_value
+      .GetService.return_value
+      .getCustomTargetingKeysByStatement) = MagicMock(
+        return_value={
+          'totalResultSetSize': 0,
+          'startIndex': 0
+      })
+
+    response = dfp.get_custom_targeting.get_key_id_by_name('hb_pb')
+
+    self.assertEqual(response, None)


### PR DESCRIPTION
Fix error when fetching a custom DFP targeting key ID by name when no key exists.

Fixes #2 .