### PR TITLE
Remove 1x1 from creative placeholders. Update to v201802 as v201702 is now deprecated. Upgrade to googleads 7.0.0. Change key type from P12 to JSON.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ _You will need credentials to access your DFP account programmatically. This sum
 2. Create Google developer credentials
    * Go to the [Google Developers Console Credentials page](https://console.developers.google.com/apis/credentials).
    * On the **Credentials** page, select **Create credentials**, then select **Service account key**.
-   * Select **New service account**, and select P12 key type.
-   * Click **Create** to download a file containing a `.p12` private key. Take note of the password (probably Google's default, "notasecret").
+   * Select **New service account**, and select JSON key type.
+   * Click **Create** to download a file containing a `.json` private key.
 3. Enable API access to DFP
    * Sign into your [DFP account](https://www.google.com/dfp/). You must have admin rights.
    * Select the **Admin** tab.
@@ -32,10 +32,8 @@ _You will need credentials to access your DFP account programmatically. This sum
 ### Setting Up
 1. Clone this repository.
 2. Run `pip install -r requirements.txt`.
-3. Convert the PKCS12 key format to PEM
-   * Rename the Google credentials key you previously downloaded (`[something].p12`) to `key.p12` and move it to the root of this repository
-   * Run `openssl pkcs12 -in key.p12 -nodes -nocerts > key.pem`. Enter your password.
-   * Delete `key.p12`.
+3. Rename key
+   * Rename the Google credentials key you previously downloaded (`[something].json`) to `key.json` and move it to the root of this repository
 4. Make a copy of `googleads.example.yaml` and name it `googleads.yaml`.
 5. In `googleads.yaml`, set the required fields:
    * `application_name` is the name of the application you used to get your Google developer credentials

--- a/dfp/associate_line_items_and_creatives.py
+++ b/dfp/associate_line_items_and_creatives.py
@@ -19,7 +19,7 @@ def make_licas(line_item_ids, creative_ids, size_overrides=[]):
   """
   dfp_client = get_client()
   lica_service = dfp_client.GetService(
-    'LineItemCreativeAssociationService', version='v201702')
+    'LineItemCreativeAssociationService', version='v201802')
 
   sizes = []
 
@@ -35,7 +35,7 @@ def make_licas(line_item_ids, creative_ids, size_overrides=[]):
         # "Overrides the value set for Creative.size, which allows the
         #   creative to be served to ad units that would otherwise not be
         #   compatible for its actual size."
-        #    https://developers.google.com/doubleclick-publishers/docs/reference/v201702/LineItemCreativeAssociationService.LineItemCreativeAssociation
+        #    https://developers.google.com/doubleclick-publishers/docs/reference/v201802/LineItemCreativeAssociationService.LineItemCreativeAssociation
         #
         # This is equivalent to selecting "Size overrides" in the DFP creative
         # settings, as recommended: http://prebid.org/adops/step-by-step.html

--- a/dfp/create_creatives.py
+++ b/dfp/create_creatives.py
@@ -21,7 +21,7 @@ def create_creatives(creatives):
   """
   dfp_client = get_client()
   creative_service = dfp_client.GetService('CreativeService',
-    version='v201702')
+    version='v201802')
   creatives = creative_service.createCreatives(creatives)
 
   # Return IDs of created line items.
@@ -48,7 +48,7 @@ def create_creative_config(name, advertiser_id):
   with open(snippet_file_path, 'r') as snippet_file:
       snippet = snippet_file.read()
 
-  # https://developers.google.com/doubleclick-publishers/docs/reference/v201702/CreativeService.Creative
+  # https://developers.google.com/doubleclick-publishers/docs/reference/v201802/CreativeService.Creative
   config = {
     'xsi_type': 'ThirdPartyCreative',
     'name': name,

--- a/dfp/create_custom_targeting.py
+++ b/dfp/create_custom_targeting.py
@@ -23,7 +23,7 @@ def create_targeting_key(name, display_name=None, key_type='FREEFORM'):
 
   dfp_client = get_client()
   custom_targeting_service = dfp_client.GetService('CustomTargetingService',
-    version='v201702')
+    version='v201802')
 
   if display_name is None:
     display_name = name
@@ -60,7 +60,7 @@ def create_targeting_value(name, key_id):
 
   dfp_client = get_client()
   custom_targeting_service = dfp_client.GetService('CustomTargetingService',
-    version='v201702')
+    version='v201802')
 
   values_config = [
     {

--- a/dfp/create_line_items.py
+++ b/dfp/create_line_items.py
@@ -14,7 +14,7 @@ def create_line_items(line_items):
     an array: an array of created line item IDs
   """
   dfp_client = get_client()
-  line_item_service = dfp_client.GetService('LineItemService', version='v201702')
+  line_item_service = dfp_client.GetService('LineItemService', version='v201802')
   line_items = line_item_service.createLineItems(line_items)
 
   # Return IDs of created line items.
@@ -53,7 +53,7 @@ def create_line_item_config(name, order_id, placement_ids, cpm_micro_amount,
     })
 
   # Create key/value targeting for Prebid.
-  # https://github.com/googleads/googleads-python-lib/blob/master/examples/dfp/v201702/line_item_service/target_custom_criteria.py
+  # https://github.com/googleads/googleads-python-lib/blob/master/examples/dfp/v201802/line_item_service/target_custom_criteria.py
   # create custom criterias
 
   hb_bidder_criteria = {
@@ -79,11 +79,11 @@ def create_line_item_config(name, order_id, placement_ids, cpm_micro_amount,
     'children': [hb_bidder_criteria, hb_pb_criteria]
   }
 
-  # https://developers.google.com/doubleclick-publishers/docs/reference/v201702/LineItemService.LineItem
+  # https://developers.google.com/doubleclick-publishers/docs/reference/v201802/LineItemService.LineItem
   line_item_config = {
     'name': name,
     'orderId': order_id,
-    # https://developers.google.com/doubleclick-publishers/docs/reference/v201702/LineItemService.Targeting
+    # https://developers.google.com/doubleclick-publishers/docs/reference/v201802/LineItemService.Targeting
     'targeting': {
       'inventoryTargeting': {
         'targetedPlacementIds': placement_ids

--- a/dfp/create_line_items.py
+++ b/dfp/create_line_items.py
@@ -45,14 +45,8 @@ def create_line_item_config(name, order_id, placement_ids, cpm_micro_amount,
   """
 
   # Set up sizes.
-  creative_placeholders = [
-    {
-      'size': {
-        'width': '1',
-        'height': '1'
-      },
-    },
-  ]
+  creative_placeholders = []
+  
   for size in sizes:
     creative_placeholders.append({
       'size': size

--- a/dfp/create_orders.py
+++ b/dfp/create_orders.py
@@ -66,7 +66,7 @@ def create_order(order_name, advertiser_id, trafficker_id):
       create_order_config(name=order_name, advertiser_id=advertiser_id,
         trafficker_id=trafficker_id)
     ]
-    order_service = dfp_client.GetService('OrderService', version='v201702')
+    order_service = dfp_client.GetService('OrderService', version='v201802')
     orders = order_service.createOrders(orders)
 
     order = orders[0]

--- a/dfp/get_advertisers.py
+++ b/dfp/get_advertisers.py
@@ -25,7 +25,7 @@ def create_advertiser(name):
     an integer: the advertiser's DFP ID
   """
   dfp_client = get_client()
-  company_service = dfp_client.GetService('CompanyService', version='v201702')
+  company_service = dfp_client.GetService('CompanyService', version='v201802')
 
   advertisers_config = [
     {
@@ -54,7 +54,7 @@ def get_advertiser_id_by_name(name):
     an integer: the advertiser's DFP ID
   """
   dfp_client = get_client()
-  company_service = dfp_client.GetService('CompanyService', version='v201702')
+  company_service = dfp_client.GetService('CompanyService', version='v201802')
 
   # Filter by name.
   query = 'WHERE name = :name'

--- a/dfp/get_custom_targeting.py
+++ b/dfp/get_custom_targeting.py
@@ -21,7 +21,7 @@ def get_key_id_by_name(name):
 
   dfp_client = get_client()
   custom_targeting_service = dfp_client.GetService('CustomTargetingService',
-    version='v201702')
+    version='v201802')
 
   # Get a key by name.
   query = ('WHERE name = :name')
@@ -57,7 +57,7 @@ def get_targeting_by_key_name(name):
 
   dfp_client = get_client()
   custom_targeting_service = dfp_client.GetService('CustomTargetingService',
-    version='v201702')
+    version='v201802')
 
   # Get a key by name.
   query = ('WHERE name = :name')

--- a/dfp/get_orders.py
+++ b/dfp/get_orders.py
@@ -22,7 +22,7 @@ def get_order_by_name(order_name):
   """
 
   dfp_client = get_client()
-  order_service = dfp_client.GetService('OrderService', version='v201702')
+  order_service = dfp_client.GetService('OrderService', version='v201802')
 
   # Filter by name.
   query = 'WHERE name = :name'
@@ -61,7 +61,7 @@ def get_all_orders(print_orders=False):
   dfp_client = get_client()
 
   # Initialize appropriate service.
-  order_service = dfp_client.GetService('OrderService', version='v201702')
+  order_service = dfp_client.GetService('OrderService', version='v201802')
 
   # Create a statement to select orders.
   statement = dfp.FilterStatement()

--- a/dfp/get_placements.py
+++ b/dfp/get_placements.py
@@ -27,7 +27,7 @@ def get_placement_by_name(placement_name):
 
   dfp_client = get_client()
   placement_service = dfp_client.GetService('PlacementService',
-    version='v201702')
+    version='v201802')
 
   query = 'WHERE name = :name'
   values = [

--- a/dfp/get_users.py
+++ b/dfp/get_users.py
@@ -21,7 +21,7 @@ def get_user_id_by_email(email_address):
     an integer: the user's DFP ID
   """
   dfp_client = get_client()
-  user_service = dfp_client.GetService('UserService', version='v201702')
+  user_service = dfp_client.GetService('UserService', version='v201802')
 
   # Filter by email address.
   query = 'WHERE email = :email'

--- a/googleads.example.yaml
+++ b/googleads.example.yaml
@@ -18,4 +18,4 @@ dfp:
   #############################################################################
   # The following values configure the client for the service account flow.
   service_account_email: INSERT_SERVICE_ACCOUNT_EMAIL_HERE
-  path_to_private_key_file: ./key.pem
+  path_to_private_key_file: ./key.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 colorama==0.3.7
 future==0.16.0
-googleads==5.1.0
+googleads==7.0.0
 mock==2.0.0
 pycryptodome==3.4.11
 PyYAML==3.12

--- a/tests/test_dfp_create_line_items.py
+++ b/tests/test_dfp_create_line_items.py
@@ -1,6 +1,6 @@
 
 from unittest import TestCase
-from mock import MagicMock, Mock, patch
+from mock import MagicMock, patch
 
 import settings
 import dfp.create_line_items
@@ -96,12 +96,6 @@ class DFPCreateLineItemsTests(TestCase):
         'creativePlaceholders': [
           {
             'size': {
-              'width': '1',
-              'height': '1'
-            },
-          },
-          {
-            'size': {
               'width': '728',
               'height': '90'
             }
@@ -165,12 +159,6 @@ class DFPCreateLineItemsTests(TestCase):
         'creativePlaceholders': [
           {
             'size': {
-              'width': '1',
-              'height': '1'
-            },
-          },
-          {
-            'size': {
               'width': '728',
               'height': '90'
             }
@@ -218,11 +206,6 @@ class DFPCreateLineItemsTests(TestCase):
           'contractedUnitsBought': 0,
           'creativePlaceholders': [
             {
-              'size': {
-                'width': 1,
-                'height': 1,
-                'isAspectRatio': False,
-              },
               'expectedCreativeCount': 1,
               'creativeSizeType': 'PIXEL',
             },


### PR DESCRIPTION
Additional fix to #20 as creative placeholders are still using 1x1 placement size, which is not required.