### PR TITLE
Implement RON support and Bidder Code Params

### DIFF
--- a/dfp/create_creatives.py
+++ b/dfp/create_creatives.py
@@ -7,6 +7,8 @@ from googleads import dfp
 
 from dfp.client import get_client
 
+import settings
+
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +49,19 @@ def create_creative_config(name, advertiser_id):
     'creative_snippet.html')
   with open(snippet_file_path, 'r') as snippet_file:
       snippet = snippet_file.read()
+
+  # Determine what bidder params should be
+  bidder_code = getattr(settings, 'PREBID_BIDDER_CODE', None)
+  bidder_params = getattr(settings, 'PREBID_BIDDER_PARAMS', None)
+  hb_adid_key = 'hb_adid'
+
+  if bidder_params is True:
+    hb_adid_key += '_' + bidder_code
+
+    if len(hb_adid_key) > 20:
+      hb_adid_key = hb_adid_key[:20]
+
+  snippet = snippet.replace('{hb_adid_key}', hb_adid_key)
 
   # https://developers.google.com/doubleclick-publishers/docs/reference/v201802/CreativeService.Creative
   config = {

--- a/dfp/create_line_items.py
+++ b/dfp/create_line_items.py
@@ -25,7 +25,7 @@ def create_line_items(line_items):
 
 def create_line_item_config(name, order_id, placement_ids, cpm_micro_amount,
   sizes, hb_bidder_key_id, hb_pb_key_id, hb_bidder_value_id, hb_pb_value_id,
-  currency_code='USD', root_ad_unit=None):
+  currency_code='USD', root_ad_unit_id=None):
   """
   Creates a line item config object.
 
@@ -83,11 +83,11 @@ def create_line_item_config(name, order_id, placement_ids, cpm_micro_amount,
     'targetedPlacementIds': placement_ids
   }
 
-  if not root_ad_unit is None:
+  if not root_ad_unit_id is None:
     targeting = {
       'targetedAdUnits': [{
-        'adUnitId': root_ad_unit['id'],
-        'includeDescendants': True
+        'adUnitId': root_ad_unit_id,
+        'includeDescendants': 'true'
       }]
     }
 

--- a/dfp/creative_snippet.html
+++ b/dfp/creative_snippet.html
@@ -4,7 +4,7 @@ for (i = 0; i < 10; i++) {
   w = w.parent;
   if (w.pbjs) {
     try {
-      w.pbjs.renderAd(document, '%%PATTERN:hb_adid%%');
+      w.pbjs.renderAd(document, '%%PATTERN:{hb_adid_key}%%');
       break;
     } catch (e) {
       continue;

--- a/dfp/get_ad_units.py
+++ b/dfp/get_ad_units.py
@@ -44,17 +44,21 @@ def get_all_ad_units(print_ad_units=False):
 
   return ad_units
 
-def get_root_ad_unit():
+def get_root_ad_unit_id():
   """
-  Gets root ad unit from DFP.
+  Gets root ad unit ID from DFP.
 
   Returns:
-    an ad unit, or None
+    an ad unit ID, or None
   """
-  ad_units = get_all_ad_units()
-  for ad_unit in ad_units:
-    if not hasattr(ad_unit, 'parentId'):
-      return ad_unit	
+
+  dfp_client = get_client()
+  network_service = dfp_client.GetService('NetworkService', version='v201802')
+  current_network = network_service.getCurrentNetwork()
+
+  if hasattr(current_network, 'effectiveRootAdUnitId'):
+    return current_network.effectiveRootAdUnitId
+
   return None
 
 def main():

--- a/settings.py
+++ b/settings.py
@@ -70,7 +70,7 @@ DFP_USE_EXISTING_ORDER_IF_EXISTS = False
 PREBID_BIDDER_CODE = None
 
 # Whether DFP targeting keys should be created following Bidders' Params structure.
-# This is used when it's required to sen all bids to the ad server.
+# This is used when it's required to send all bids to the ad server.
 # See: http://prebid.org/dev-docs/bidders.html
 # And: http://prebid.org/adops/send-all-bids-adops.html
 PREBID_BIDDER_PARAMS = True

--- a/settings.py
+++ b/settings.py
@@ -38,8 +38,6 @@ DFP_PLACEMENT_SIZES = [
 # still need to be set to empty arrays.
 DFP_ALLOW_NO_INVENTORY_TARGETING = False
 
-# 
-
 # Whether we should create the advertiser in DFP if it does not exist.
 # If False, the program will exit rather than create an advertiser.
 DFP_CREATE_ADVERTISER_IF_DOES_NOT_EXIST = False

--- a/settings.py
+++ b/settings.py
@@ -21,9 +21,6 @@ DFP_ADVERTISER_NAME = None
 # Names of placements the line items should target. Has priority over ad units.
 DFP_TARGETED_PLACEMENT_NAMES = []
 
-# Names of ad units the line items should target.
-DFP_TARGETED_ADUNIT_NAMES = []
-
 # Sizes of placements. These are used to set line item and creative sizes.
 DFP_PLACEMENT_SIZES = [
   {
@@ -74,8 +71,10 @@ DFP_USE_EXISTING_ORDER_IF_EXISTS = False
 
 PREBID_BIDDER_CODE = None
 
-# Whether DFP targeting keys should be created following Bidders' Params structure
+# Whether DFP targeting keys should be created following Bidders' Params structure.
+# This is used when it's required to sen all bids to the ad server.
 # See: http://prebid.org/dev-docs/bidders.html
+# And: http://prebid.org/adops/send-all-bids-adops.html
 PREBID_BIDDER_PARAMS = True
 
 # Price buckets. This should match your Prebid settings for the partner. See:

--- a/settings.py
+++ b/settings.py
@@ -37,8 +37,8 @@ DFP_PLACEMENT_SIZES = [
 ]
 
 # If no placement or ad unit should be used, for example if the user wants a run  
-# of network. If True, DFP_PLACEMENT_SIZE and DFP_TARGETED_PLACEMENT_NAMES need 
-# to be set to an empty array.
+# of network. If True, DFP_TARGETED_PLACEMENT_NAMES and DFP_TARGETED_ADUNIT_NAMES 
+# still need to be set to empty arrays.
 DFP_ALLOW_NO_INVENTORY_TARGETING = False
 
 # Whether we should create the advertiser in DFP if it does not exist.

--- a/settings.py
+++ b/settings.py
@@ -41,6 +41,8 @@ DFP_PLACEMENT_SIZES = [
 # still need to be set to empty arrays.
 DFP_ALLOW_NO_INVENTORY_TARGETING = False
 
+# 
+
 # Whether we should create the advertiser in DFP if it does not exist.
 # If False, the program will exit rather than create an advertiser.
 DFP_CREATE_ADVERTISER_IF_DOES_NOT_EXIST = False
@@ -71,6 +73,10 @@ DFP_USE_EXISTING_ORDER_IF_EXISTS = False
 #########################################################################
 
 PREBID_BIDDER_CODE = None
+
+# Whether DFP targeting keys should be created following Bidders' Params structure
+# See: http://prebid.org/dev-docs/bidders.html
+PREBID_BIDDER_PARAMS = True
 
 # Price buckets. This should match your Prebid settings for the partner. See:
 # http://prebid.org/dev-docs/publisher-api-reference.html#module_pbjs.setPriceGranularity

--- a/tasks/add_new_prebid_partner.py
+++ b/tasks/add_new_prebid_partner.py
@@ -211,9 +211,9 @@ def create_line_item_configs(prices, order_id, placement_ids, bidder_code,
 
   if not placement_ids:
     # Since the placement ids array is empty, it means we should target a run of network for the line item
-    root_ad_unit = dfp.get_ad_units.get_root_ad_unit()
+    root_ad_unit_id = dfp.get_ad_units.get_root_ad_unit_id()
 
-    if root_ad_unit is None:
+    if root_ad_unit_id is None:
       raise DFPObjectNotFound('Could not find the root ad unit to target a run of network.')
 
   for price in prices:
@@ -240,7 +240,7 @@ def create_line_item_configs(prices, order_id, placement_ids, bidder_code,
       hb_bidder_value_id=hb_bidder_value_id,
       hb_pb_value_id=hb_pb_value_id,
       currency_code=currency_code,
-      root_ad_unit=root_ad_unit
+      root_ad_unit_id=root_ad_unit_id
     )
 
     line_items_config.append(config)

--- a/tasks/add_new_prebid_partner.py
+++ b/tasks/add_new_prebid_partner.py
@@ -207,7 +207,7 @@ def create_line_item_configs(prices, order_id, placement_ids, bidder_code,
   hb_bidder_value_id = HBBidderValueGetter.get_value_id(bidder_code)
 
   line_items_config = []
-  root_ad_unit = None
+  root_ad_unit_id = None
 
   if not placement_ids:
     # Since the placement ids array is empty, it means we should target a run of network for the line item

--- a/tests/test_dfp_create_creatives.py
+++ b/tests/test_dfp_create_creatives.py
@@ -43,6 +43,19 @@ class DFPCreateCreativesTests(TestCase):
     with open(snippet_file_path, 'r') as snippet_file:
         snippet = snippet_file.read()
 
+    # Determine what bidder params should be
+    bidder_code = getattr(settings, 'PREBID_BIDDER_CODE', None)
+    bidder_params = getattr(settings, 'PREBID_BIDDER_PARAMS', None)
+    hb_adid_key = 'hb_adid'
+
+    if bidder_params is True:
+      hb_adid_key += '_' + bidder_code
+
+      if len(hb_adid_key) > 20:
+        hb_adid_key = hb_adid_key[:20]
+
+    snippet = snippet.replace('{hb_adid_key}', hb_adid_key)
+
     self.assertEqual(
       dfp.create_creatives.create_creative_config(
         name='My Creative',

--- a/tests/test_dfp_create_line_items.py
+++ b/tests/test_dfp_create_line_items.py
@@ -28,6 +28,7 @@ class DFPCreateLineItemsTests(TestCase):
         hb_pb_key_id=888888,
         hb_bidder_value_id=222222,
         hb_pb_value_id=111111,
+        root_ad_unit_id=None
       )
     ]
 
@@ -57,6 +58,7 @@ class DFPCreateLineItemsTests(TestCase):
         hb_pb_key_id=888888,
         hb_bidder_value_id=222222,
         hb_pb_value_id=111111,
+        root_ad_unit_id=None
       ),
       {
         'orderId': 1234567,
@@ -68,15 +70,15 @@ class DFPCreateLineItemsTests(TestCase):
           'customTargeting': {
             'children': [
               {
-                'keyId': 999999,
-                'operator': 'IS',
-                'valueIds': [222222],
-                'xsi_type': 'CustomCriteria'
-              },
-              {
                 'keyId': 888888,
                 'operator': 'IS',
                 'valueIds': [111111],
+                'xsi_type': 'CustomCriteria'
+              },
+              {
+                'keyId': 999999,
+                'operator': 'IS',
+                'valueIds': [222222],
                 'xsi_type': 'CustomCriteria'
               }
             ],
@@ -120,6 +122,7 @@ class DFPCreateLineItemsTests(TestCase):
         hb_bidder_value_id=222222,
         hb_pb_value_id=111111,
         currency_code='EUR',
+        root_ad_unit_id=None
       ),
       {
         'orderId': 22334455,
@@ -131,15 +134,15 @@ class DFPCreateLineItemsTests(TestCase):
           'customTargeting': {
             'children': [
               {
-                'keyId': 999999,
-                'operator': 'IS',
-                'valueIds': [222222],
-                'xsi_type': 'CustomCriteria'
-              },
-              {
                 'keyId': 888888,
                 'operator': 'IS',
                 'valueIds': [111111],
+                'xsi_type': 'CustomCriteria'
+              },
+              {
+                'keyId': 999999,
+                'operator': 'IS',
+                'valueIds': [222222],
                 'xsi_type': 'CustomCriteria'
               }
             ],

--- a/tests/test_dfp_get_ad_units.py
+++ b/tests/test_dfp_get_ad_units.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+from unittest import TestCase
+from mock import MagicMock, Mock, patch
+
+import dfp.get_orders
+
+
+@patch('googleads.dfp.DfpClient.LoadFromStorage')
+class DFPServiceTests(TestCase):
+  
+  def test_get_all_ad_units(self, mock_dfp_client):
+    """
+    Ensure `get_all_ad_units` makes one call to DFP.
+    """
+    mock_dfp_client.return_value = MagicMock()
+
+    # Response for fetching ad units.
+    (mock_dfp_client.return_value
+      .GetService.return_value
+      .getAdUnitsByStatement) = MagicMock()
+
+    dfp.get_ad_units.get_all_ad_units()
+
+    # Confirm that it loaded the mock DFP client.
+    mock_dfp_client.assert_called_once()
+
+    expected_arg = {'query': 'LIMIT 500 OFFSET 0', 'values': None}
+    (mock_dfp_client.return_value
+      .GetService.return_value
+      .getAdUnitsByStatement.assert_called_once_with(expected_arg)
+      )


### PR DESCRIPTION
Fixes #16 - used suggested parameter DFP_ALLOW_NO_INVENTORY_TARGETING when no DFP_TARGETED_PLACEMENT_NAMES is provided.

I also needed Bidders' Params to be used when sending all bids to the ad server was required (see: http://prebid.org/dev-docs/bidders.html and http://prebid.org/adops/send-all-bids-adops.html), so I added the PREBID_BIDDER_PARAMS parameter for that purpose. It's important to note that when that parameter is used, hb_bidder is not matched against Bidder Code.

I also put the base to retrieve ad units when required, although it was finally not used (preferred to extract root ad unit id directly from network). But that could eventually be used to fix #17 !