### PR TITLE
Added line item name format `DFP_LINE_ITEM_FORMAT` to settings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Setting | Description | Default
 `DFP_USE_EXISTING_ORDER_IF_EXISTS` | Whether we should modify an existing order if one already exists with name `DFP_ORDER_NAME` | `False`
 `DFP_NUM_CREATIVES_PER_LINE_ITEM` | The number of duplicate creatives to attach to each line item. Due to GAM limitations, this should be equal to or greater than the number of ad units you serve on a given page. | the length of setting `DFP_TARGETED_PLACEMENT_NAMES`
 `DFP_CURRENCY_CODE` | The currency to use in line items. | `'USD'`
+`DFP_LINE_ITEM_FORMAT` | The format for line item name. | `u'{bidder_code}: HB ${price}'`
 
 ## Limitations
 

--- a/settings.py
+++ b/settings.py
@@ -61,6 +61,11 @@ DFP_USE_EXISTING_ORDER_IF_EXISTS = False
 # The currency to use in DFP when setting line item CPMs. Defaults to 'USD'.
 # DFP_CURRENCY_CODE = 'USD'
 
+# Optional
+# The format for line item name. Defaults to u'{bidder_code}: HB ${price}'.
+# This should be specified in python's format syntax.
+# DFP_LINE_ITEM_FORMAT = u'{bidder_code}: HB ${price:0>5}'
+
 #########################################################################
 # PREBID SETTINGS
 #########################################################################


### PR DESCRIPTION
I want to customize the format of line item name.
`DFP_LINE_ITEM_FORMAT` is customizable with python's format syntax.

example:
```
DFP_LINE_ITEM_FORMAT = u'{bidder_code}: HB ${price:0>5}'
```