### PR TITLE
Fix up no creative error while only ad units specified

### DIFF
--- a/tasks/add_new_prebid_partner.py
+++ b/tasks/add_new_prebid_partner.py
@@ -152,7 +152,7 @@ def get_or_create_dfp_targeting_key(name):
   Get or create a custom targeting key by name.
 
   Args:
-    name (str)  
+    name (str)
   Returns:
     an integer: the ID of the targeting key
   """
@@ -229,7 +229,7 @@ def check_price_buckets_validity(price_buckets):
   except KeyError:
     raise BadSettingException('The setting "PREBID_PRICE_BUCKETS" '
       'must contain keys "precision", "min", "max", and "increment".')
-  
+
   if not (isinstance(pb_precision, int) or isinstance(pb_precision, float)):
     raise BadSettingException('The "precision" key in "PREBID_PRICE_BUCKETS" '
       'must be a number.')
@@ -267,7 +267,7 @@ def main():
   user_email = getattr(settings, 'DFP_USER_EMAIL_ADDRESS', None)
   if user_email is None:
     raise MissingSettingException('DFP_USER_EMAIL_ADDRESS')
-   
+
   advertiser_name = getattr(settings, 'DFP_ADVERTISER_NAME', None)
   if advertiser_name is None:
     raise MissingSettingException('DFP_ADVERTISER_NAME')
@@ -301,7 +301,7 @@ def main():
   # https://github.com/kmjennison/dfp-prebid-setup/issues/13
   num_creatives = (
     getattr(settings, 'DFP_NUM_CREATIVES_PER_LINE_ITEM', None) or
-    len(placements)
+    len(placements) + len(ad_units)
   )
 
   bidder_code = getattr(settings, 'PREBID_BIDDER_CODE', None)

--- a/tests/test_add_new_prebid_partner.py
+++ b/tests/test_add_new_prebid_partner.py
@@ -211,7 +211,7 @@ class AddNewPrebidPartnerTests(TestCase):
     tasks.add_new_prebid_partner.main()
     args, kwargs = mock_setup_partners.call_args
     num_creatives = args[8]
-    self.assertEqual(num_creatives, len(placements))
+    self.assertEqual(num_creatives, len(placements) + len(ad_units))
 
   @patch('tasks.add_new_prebid_partner.create_line_item_configs')
   @patch('tasks.add_new_prebid_partner.DFPValueIdGetter')

--- a/tests/test_add_new_prebid_partner.py
+++ b/tests/test_add_new_prebid_partner.py
@@ -202,16 +202,46 @@ class AddNewPrebidPartnerTests(TestCase):
   @patch('settings.DFP_NUM_CREATIVES_PER_LINE_ITEM', None, create=True)
   @patch('tasks.add_new_prebid_partner.setup_partner')
   @patch('tasks.add_new_prebid_partner.input', return_value='y')
-  def test_num_duplicate_creatives_no_settings(self, mock_input, 
+  def test_num_duplicate_creatives_no_settings_from_placements_and_ad_units(self, mock_input,
     mock_setup_partners, mock_dfp_client):
     """
-    Make sure we use the default number of creatives per line item if the
-    setting does not exist.
+    Make sure we consider placement and ad units as default number of creatives
+    per line item if the setting does not exist.
     """
     tasks.add_new_prebid_partner.main()
     args, kwargs = mock_setup_partners.call_args
     num_creatives = args[8]
     self.assertEqual(num_creatives, len(placements) + len(ad_units))
+
+  @patch('settings.DFP_NUM_CREATIVES_PER_LINE_ITEM', None, create=True)
+  @patch('tasks.add_new_prebid_partner.setup_partner')
+  @patch('tasks.add_new_prebid_partner.input', return_value='y')
+  def test_num_duplicate_creatives_no_settings_from_placements(self, mock_input,
+                                               mock_setup_partners, mock_dfp_client):
+    """
+    Make sure we use placements as the default number of creatives per line item
+    if the setting does not exist.
+    """
+    settings.DFP_TARGETED_AD_UNIT_NAMES = []
+    tasks.add_new_prebid_partner.main()
+    args, kwargs = mock_setup_partners.call_args
+    num_creatives = args[8]
+    self.assertEqual(num_creatives, len(placements))
+
+  @patch('settings.DFP_NUM_CREATIVES_PER_LINE_ITEM', None, create=True)
+  @patch('tasks.add_new_prebid_partner.setup_partner')
+  @patch('tasks.add_new_prebid_partner.input', return_value='y')
+  def test_num_duplicate_creatives_no_settings_from_ad_units(self, mock_input,
+                                               mock_setup_partners, mock_dfp_client):
+    """
+    Make sure we use ad units as the default number of creatives per line item
+    if the setting does not exist.
+    """
+    settings.DFP_TARGETED_PLACEMENT_NAMES = []
+    tasks.add_new_prebid_partner.main()
+    args, kwargs = mock_setup_partners.call_args
+    num_creatives = args[8]
+    self.assertEqual(num_creatives, len(ad_units))
 
   @patch('tasks.add_new_prebid_partner.create_line_item_configs')
   @patch('tasks.add_new_prebid_partner.DFPValueIdGetter')


### PR DESCRIPTION
As #64 was merged, one small issue is that if user uses only ad unit targeting and keep `DFP_NUM_CREATIVES_PER_LINE_ITEM` unset, there will be no creative created.