### PR TITLE
Support one order for all bidders #18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ googleads.yaml
 secret-files.tar
 *.pyc
 local_settings.py
+.vscode
+

--- a/dfp/create_creatives.py
+++ b/dfp/create_creatives.py
@@ -74,7 +74,11 @@ def build_creative_name(bidder_code, order_name, creative_num):
     Returns:
       a string
     """
-    return '{bidder_code}: HB {order_name}, #{num}'.format(
+    if bidder_code is None:
+      bidder_code_format = '{bidder_code}: HB {order_name}, #{num}'
+    else:
+      bidder_code_format = 'HB {order_name}, #{num}'
+    return bidder_code_format.format(
         bidder_code=bidder_code, order_name=order_name, num=creative_num)
 
 def create_duplicate_creative_configs(bidder_code, order_name, advertiser_id,

--- a/dfp/create_creatives.py
+++ b/dfp/create_creatives.py
@@ -74,7 +74,7 @@ def build_creative_name(bidder_code, order_name, creative_num):
     Returns:
       a string
     """
-    if bidder_code is None:
+    if bidder_code is not None:
       bidder_code_format = '{bidder_code}: HB {order_name}, #{num}'
     else:
       bidder_code_format = 'HB {order_name}, #{num}'

--- a/dfp/create_line_items.py
+++ b/dfp/create_line_items.py
@@ -72,12 +72,21 @@ def create_line_item_config(name, order_id, placement_ids, ad_unit_ids, cpm_micr
 
   # The custom criteria will resemble:
   # (hb_bidder_criteria.key == hb_bidder_criteria.value AND
-  #    hb_pb_criteria.key == hb_pb_criteria.value)
+  #    hb_pb_criteria.key == hb_pb_criteria.value)  
   top_set = {
     'xsi_type': 'CustomCriteriaSet',
     'logicalOperator': 'AND',
-    'children': [hb_bidder_criteria, hb_pb_criteria]
+    'children': [hb_pb_criteria]
   }
+
+  if hb_bidder_key_id is not None:
+    hb_bidder_criteria = {
+      'xsi_type': 'CustomCriteria',
+      'keyId': hb_bidder_key_id,
+      'valueIds': [hb_bidder_value_id],
+      'operator': 'IS'
+    }
+    top_set['children'].append(hb_bidder_criteria)
 
   # https://developers.google.com/doubleclick-publishers/docs/reference/v201802/LineItemService.LineItem
   line_item_config = {

--- a/dfp/create_line_items.py
+++ b/dfp/create_line_items.py
@@ -56,13 +56,6 @@ def create_line_item_config(name, order_id, placement_ids, ad_unit_ids, cpm_micr
   # https://github.com/googleads/googleads-python-lib/blob/master/examples/dfp/v201802/line_item_service/target_custom_criteria.py
   # create custom criterias
 
-  hb_bidder_criteria = {
-    'xsi_type': 'CustomCriteria',
-    'keyId': hb_bidder_key_id,
-    'valueIds': [hb_bidder_value_id],
-    'operator': 'IS'
-  }
-
   hb_pb_criteria = {
     'xsi_type': 'CustomCriteria',
     'keyId': hb_pb_key_id,

--- a/tasks/add_new_prebid_partner.py
+++ b/tasks/add_new_prebid_partner.py
@@ -305,7 +305,14 @@ def main():
 
   currency_code = getattr(settings, 'DFP_CURRENCY_CODE', 'USD')
 
-  line_item_format = getattr(settings, 'DFP_LINE_ITEM_FORMAT', u'{bidder_code}: HB ${price}')
+  bidder_code = getattr(settings, 'PREBID_BIDDER_CODE', None)
+
+  if bidder_code is not None:
+    default_line_item_format = u'{bidder_code}: HB ${price}'
+  else:
+    default_line_item_format = u'HB ${price}'
+
+  line_item_format = getattr(settings, 'DFP_LINE_ITEM_FORMAT', default_line_item_format)
 
   # How many creatives to attach to each line item. We need at least one
   # creative per ad unit on a page. See:
@@ -314,8 +321,6 @@ def main():
     getattr(settings, 'DFP_NUM_CREATIVES_PER_LINE_ITEM', None) or
     len(placements) + len(ad_units)
   )
-
-  bidder_code = getattr(settings, 'PREBID_BIDDER_CODE', None)
 
   price_buckets = getattr(settings, 'PREBID_PRICE_BUCKETS', None)
   if price_buckets is None:

--- a/tasks/add_new_prebid_partner.py
+++ b/tasks/add_new_prebid_partner.py
@@ -77,11 +77,19 @@ def setup_partner(user_email, advertiser_name, order_name, placements, ad_units,
   creative_ids = dfp.create_creatives.create_creatives(creative_configs)
 
   # Get DFP key IDs for line item targeting.
-  hb_bidder_key_id = get_or_create_dfp_targeting_key('hb_bidder')
+  if bidder_code is not None: 
+    hb_bidder_key_id = get_or_create_dfp_targeting_key('hb_bidder')
+  else:
+    hb_bidder_key_id = None
+  
   hb_pb_key_id = get_or_create_dfp_targeting_key('hb_pb')
 
   # Instantiate DFP targeting value ID getters for the targeting keys.
-  HBBidderValueGetter = DFPValueIdGetter('hb_bidder')
+  if bidder_code is not None:
+    HBBidderValueGetter = DFPValueIdGetter('hb_bidder')
+  else:
+    HBBidderValueGetter = None
+  
   HBPBValueGetter = DFPValueIdGetter('hb_pb')
 
   # Create line items.
@@ -183,7 +191,10 @@ def create_line_item_configs(prices, order_id, placement_ids, ad_unit_ids, bidde
   """
 
   # The DFP targeting value ID for this `hb_bidder` code.
-  hb_bidder_value_id = HBBidderValueGetter.get_value_id(bidder_code)
+  if HBBidderValueGetter is not None:
+    hb_bidder_value_id = HBBidderValueGetter.get_value_id(bidder_code)
+  else:
+    hb_bidder_value_id = None
 
   line_items_config = []
   for price in prices:
@@ -305,8 +316,6 @@ def main():
   )
 
   bidder_code = getattr(settings, 'PREBID_BIDDER_CODE', None)
-  if bidder_code is None:
-    raise MissingSettingException('PREBID_BIDDER_CODE')
 
   price_buckets = getattr(settings, 'PREBID_PRICE_BUCKETS', None)
   if price_buckets is None:


### PR DESCRIPTION
Added support for using no bidder for the creation of the line items, by setting:  

PREBID_BIDDER_CODE = None

in settings.py

Fixes #18 