### PR TITLE
Add support for video ad units and creatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Setting | Description | Type
 `DFP_PLACEMENT_SIZES` | The creative sizes for the targeted placements | array of objects (e.g., `[{'width': '728', 'height': '90'}]`)
 `PREBID_BIDDER_CODE` | The value of [`hb_bidder`](http://prebid.org/dev-docs/publisher-api-reference.html#module_pbjs.bidderSettings) for this partner | string
 `PREBID_PRICE_BUCKETS` | The [price granularity](http://prebid.org/dev-docs/publisher-api-reference.html#module_pbjs.setPriceGranularity); used to set `hb_pb` for each line item | object
+`DFP_VIDEO_AD_TYPE` | Set to true to create video ad units and creatives | boolean
+`DFP_VAST_REDIRECT_URL` | The redirect URL to use for video ad creatives (only used if `DFP_VIDEO_AD_TYPE` is set to True) | string
 
 Then, from the root of the repository, run:
 

--- a/dfp/create_creatives.py
+++ b/dfp/create_creatives.py
@@ -31,13 +31,15 @@ def create_creatives(creatives):
     logger.info(u'Created creative with name "{name}".'.format(name=creative['name']))
   return created_creative_ids
 
-def create_creative_config(name, advertiser_id):
+def create_creative_config(name, advertiser_id, video_ad_type, redirect_url):
   """
   Creates a creative config object.
 
   Args:
     name (str): the name of the creative
     advertiser_id (int): the ID of the advertiser in DFP
+    video_ad_type (bool): create video ads
+    redirect_url (str): if not empty, creates a redirect creative with the provided URL instead of a third party
   Returns:
     an object: the line item config
   """
@@ -49,16 +51,20 @@ def create_creative_config(name, advertiser_id):
 
   # https://developers.google.com/doubleclick-publishers/docs/reference/v201802/CreativeService.Creative
   config = {
-    'xsi_type': 'ThirdPartyCreative',
     'name': name,
     'advertiserId': advertiser_id,
-    'size': {
-      'width': '1',
-      'height': '1'
-    },
-    'snippet': snippet,
-    'isSafeFrameCompatible': True,
   }
+
+  if video_ad_type:
+    config['xsi_type'] = 'VastRedirectCreative'
+    config['duration'] = 1000
+    config['size'] = { 'width': '640', 'height': '480' }
+    config['vastXmlUrl'] = redirect_url
+  else:
+    config['xsi_type'] = 'ThirdPartyCreative'
+    config['snippet'] = snippet
+    config['isSafeFrameCompatible'] = True
+    config['size'] = { 'width': '1', 'height': '1' }
 
   return config
 
@@ -78,7 +84,7 @@ def build_creative_name(bidder_code, order_name, creative_num):
         bidder_code=bidder_code, order_name=order_name, num=creative_num)
 
 def create_duplicate_creative_configs(bidder_code, order_name, advertiser_id,
-  num_creatives=1):
+  num_creatives=1, video_ad_type=False, redirect_url=''):
   """
   Returns an array of creative config object.
 
@@ -87,6 +93,8 @@ def create_duplicate_creative_configs(bidder_code, order_name, advertiser_id,
     order_name (int): the name of the order in DFP
     advertiser_id (int): the ID of the advertiser in DFP
     num_creatives (int): how many creative configs to generate
+    video_ad_type (bool): create video ads
+    redirect_url (str): if not empty, creates a redirect creative with the provided URL instead of a third party
   Returns:
     an array: an array of length `num_creatives`, each item a line item config
   """
@@ -95,6 +103,8 @@ def create_duplicate_creative_configs(bidder_code, order_name, advertiser_id,
     config = create_creative_config(
       name=build_creative_name(bidder_code, order_name, creative_num),
       advertiser_id=advertiser_id,
+      video_ad_type=video_ad_type,
+      redirect_url=redirect_url,
     )
     creative_configs.append(config)
   return creative_configs

--- a/dfp/create_line_items.py
+++ b/dfp/create_line_items.py
@@ -24,7 +24,7 @@ def create_line_items(line_items):
   return created_line_item_ids
 
 def create_line_item_config(name, order_id, placement_ids, ad_unit_ids, cpm_micro_amount, sizes, hb_bidder_key_id,
-                            hb_pb_key_id, hb_bidder_value_id, hb_pb_value_id, currency_code='USD'):
+                            hb_pb_key_id, hb_bidder_value_id, hb_pb_value_id, currency_code='USD', video_ad_type=False):
   """
   Creates a line item config object.
 
@@ -40,6 +40,7 @@ def create_line_item_config(name, order_id, placement_ids, ad_unit_ids, cpm_micr
     hb_bidder_key_id (int): the DFP ID of the `hb_bidder` targeting key
     hb_pb_key_id (int): the DFP ID of the `hb_pb` targeting key
     currency_code (str): the currency code (e.g. 'USD' or 'EUR')
+    video_ad_type (bool): create video type line items
   Returns:
     an object: the line item config
   """
@@ -102,6 +103,11 @@ def create_line_item_config(name, order_id, placement_ids, ad_unit_ids, cpm_micr
     },
     'creativePlaceholders': creative_placeholders,
   }
+  if video_ad_type:
+    line_item_config['environmentType'] = 'VIDEO_PLAYER'
+    # https://developers.google.com/ad-manager/api/reference/v202005/LineItemService.RequestPlatformTargeting
+    line_item_config['targeting']['requestPlatformTargeting'] = { 'targetedRequestPlatforms': [ 'VIDEO_PLAYER' ] },
+
   if placement_ids is not None:
     line_item_config['targeting']['inventoryTargeting']['targetedPlacementIds'] = placement_ids
 

--- a/settings.py
+++ b/settings.py
@@ -36,17 +36,25 @@ DFP_PLACEMENT_SIZES = [
   },
 ]
 
+# If DFP_VIDEO_AD_TYPE is set to False, traditional ad units will be created.
+# If it is set to True, video ad units and creatives will be created instead.
+# When creating video ad units, you also need to fill the DFP_VAST_REDIRECT_URL value.
+DFP_VIDEO_AD_TYPE = False
+
+# Redirect URL for video creatives.
+DFP_VAST_REDIRECT_URL = ''
+
 # Whether we should create the advertiser in DFP if it does not exist.
 # If False, the program will exit rather than create an advertiser.
 DFP_CREATE_ADVERTISER_IF_DOES_NOT_EXIST = False
 
-# If settings.DFP_ORDER_NAME is the same as an existing order, add the created 
+# If settings.DFP_ORDER_NAME is the same as an existing order, add the created
 # line items to that order. If False, the program will exit rather than
 # modify an existing order.
 DFP_USE_EXISTING_ORDER_IF_EXISTS = False
 
 # Optional
-# Each line item should have at least as many creatives as the number of 
+# Each line item should have at least as many creatives as the number of
 # ad units you serve on a single page because DFP specifies:
 #   "Each of a line item's assigned creatives can only serve once per page,
 #    so if you want the same creative to appear more than once per page,

--- a/tests/test_add_new_prebid_partner.py
+++ b/tests/test_add_new_prebid_partner.py
@@ -282,7 +282,7 @@ class AddNewPrebidPartnerTests(TestCase):
     mock_create_orders.create_order.assert_called_once_with(order, 246810,
       14523)
     (mock_create_creatives.create_duplicate_creative_configs
-      .assert_called_once_with(bidder_code, order, 246810, 2))
+      .assert_called_once_with(bidder_code, order, 246810, 2, False, ''))
     mock_create_creatives.create_creatives.assert_called_once()
     mock_create_line_items.create_line_items.assert_called_once()
     mock_licas.make_licas.assert_called_once()
@@ -299,7 +299,7 @@ class AddNewPrebidPartnerTests(TestCase):
             'height': '90'
         }], hb_bidder_key_id=999999, hb_pb_key_id=888888, currency_code='HUF',
         line_item_format=u'{bidder_code}: HB ${price:0>5}', HBBidderValueGetter=MagicMock(
-            return_value=3434343434), HBPBValueGetter=MagicMock(return_value=5656565656))
+            return_value=3434343434), HBPBValueGetter=MagicMock(return_value=5656565656), video_ad_type=False)
 
     self.assertEqual(len(configs), 3)
 
@@ -317,6 +317,24 @@ class AddNewPrebidPartnerTests(TestCase):
     )
     self.assertEqual(configs[2]['costPerUnit']['microAmount'], 300000)
     self.assertEqual(configs[2]['costPerUnit']['currencyCode'], 'HUF')
+
+  def test_create_line_item_configs_video(self, mock_dfp_client):
+    """
+    It creates the expected line item configs.
+    """
+
+    configs = tasks.add_new_prebid_partner.create_line_item_configs(prices=[1], order_id=2,
+                                                                    placement_ids=[3], ad_unit_ids=None,
+                                                                    bidder_code='iamabiddr', sizes=[{
+            'width': '640',
+            'height': '480'
+        }], hb_bidder_key_id=4, hb_pb_key_id=5, currency_code='HUF',
+        line_item_format=u'{bidder_code}: HB ${price:0>5}', HBBidderValueGetter=MagicMock(
+            return_value=6), HBPBValueGetter=MagicMock(return_value=7), video_ad_type=True)
+
+    self.assertEqual(len(configs), 1)
+    self.assertEqual(configs[0]['environmentType'], 'VIDEO_PLAYER')
+    self.assertEqual(configs[0]['targeting']['requestPlatformTargeting'], ({ 'targetedRequestPlatforms': [ 'VIDEO_PLAYER' ]},))
 
   @patch('dfp.create_custom_targeting')
   @patch('dfp.get_custom_targeting')

--- a/tests/test_dfp_create_creatives.py
+++ b/tests/test_dfp_create_creatives.py
@@ -21,6 +21,8 @@ class DFPCreateCreativesTests(TestCase):
       dfp.create_creatives.create_creative_config(
         name='My Creative',
         advertiser_id=1234567,
+        video_ad_type=False,
+        redirect_url='',
       )
     ]
 
@@ -47,6 +49,8 @@ class DFPCreateCreativesTests(TestCase):
       dfp.create_creatives.create_creative_config(
         name='My Creative',
         advertiser_id=1234567,
+        video_ad_type=False,
+        redirect_url='',
       ),
       {
         'advertiserId': 1234567,
@@ -58,6 +62,26 @@ class DFPCreateCreativesTests(TestCase):
         },
         'snippet': snippet,
         'xsi_type': 'ThirdPartyCreative'
+       }
+    )
+
+    self.assertEqual(
+      dfp.create_creatives.create_creative_config(
+        name='crea',
+        advertiser_id=42,
+        video_ad_type=True,
+        redirect_url='redirectme',
+      ),
+      {
+        'advertiserId': 42,
+        'duration': 1000,
+        'name': 'crea',
+        'size': {
+          'height': '480',
+          'width': '640'
+        },
+        'vastXmlUrl': 'redirectme',
+        'xsi_type': 'VastRedirectCreative',
        }
     )
 

--- a/tests/test_dfp_create_line_items.py
+++ b/tests/test_dfp_create_line_items.py
@@ -147,6 +147,64 @@ class DFPCreateLineItemsTests(TestCase):
       }
     )
 
+    # With video ad type
+    self.assertEqual(
+      dfp.create_line_items.create_line_item_config(name='Video Line Item', order_id=42,
+                                                    placement_ids=['video-placement'],
+                                                    ad_unit_ids=['video-ad-unit'], cpm_micro_amount=40000000, sizes=[{
+          'width': '640',
+          'height': '480',
+        }], hb_bidder_key_id=999999, hb_pb_key_id=888888, hb_bidder_value_id=222222, hb_pb_value_id=111111,
+                                                    currency_code='EUR', video_ad_type=True),
+      {
+        'orderId': 42,
+        'startDateTimeType': 'IMMEDIATELY',
+        'targeting': {
+          'inventoryTargeting': {
+            'targetedAdUnits': [{'adUnitId': 'video-ad-unit'}],
+            'targetedPlacementIds': ['video-placement']
+          },
+          'customTargeting': {
+            'children': [
+              {
+                'keyId': 999999,
+                'operator': 'IS',
+                'valueIds': [222222],
+                'xsi_type': 'CustomCriteria'
+              },
+              {
+                'keyId': 888888,
+                'operator': 'IS',
+                'valueIds': [111111],
+                'xsi_type': 'CustomCriteria'
+              }
+            ],
+            'logicalOperator': 'AND',
+            'xsi_type': 'CustomCriteriaSet'
+          },
+          'requestPlatformTargeting': ({'targetedRequestPlatforms': ['VIDEO_PLAYER']},),
+        },
+        'name': 'Video Line Item',
+        'costType': 'CPM',
+        'costPerUnit': {'currencyCode': 'EUR', 'microAmount': 40000000},
+        'creativeRotationType': 'EVEN',
+        'environmentType': 'VIDEO_PLAYER',
+        'lineItemType': 'PRICE_PRIORITY',
+        'unlimitedEndDateTime': True,
+        'primaryGoal': {
+          'goalType': 'NONE'
+        },
+        'creativePlaceholders': [
+          {
+            'size': {
+              'width': '640',
+              'height': '480'
+            }
+          },
+        ],
+      }
+    )
+
   def test_create_line_items_returns_ids(self, mock_dfp_client):
     """
     Ensure it returns the IDs of created line items.


### PR DESCRIPTION
Hey,

Thanks for this great tool.
Our use case requires adding video ad units and creative, so I added this as a new feature.

I added two new settings:
- `DFP_VIDEO_AD_TYPE` which can be set to True to create video ad units and creatives instead of traditional ones
- `DFP_VAST_REDIRECT_URL` which contains the VAST redirect URL when creating video ad units
With the default settings, the processing stays the same as before.

I ran several manual tests with our GAM account and confirm both ways work, and I also added unit tests for the new features.

Keeping the original tool philosophy, I tried to minimize the changes and leave any specific need up to the user.

Any comment is welcome.