### PR TITLE
Add support of an array of price buckets and standard granuarlities

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Setting | Description | Type
 `DFP_TARGETED_PLACEMENT_NAMES` | The names of GAM placements the line items should target | array of strings
 `DFP_PLACEMENT_SIZES` | The creative sizes for the targeted placements | array of objects (e.g., `[{'width': '728', 'height': '90'}]`)
 `PREBID_BIDDER_CODE` | The value of [`hb_bidder`](http://prebid.org/dev-docs/publisher-api-reference.html#module_pbjs.bidderSettings) for this partner | string
-`PREBID_PRICE_BUCKETS` | The [price granularity](http://prebid.org/dev-docs/publisher-api-reference.html#module_pbjs.setPriceGranularity); used to set `hb_pb` for each line item | object
+`PREBID_PRICE_BUCKETS` | The [price granularity](https://docs.prebid.org/dev-docs/publisher-api-reference/setConfig.html#setConfig-Price-Granularity); used to set `hb_pb` for each line item.  Can use Prebid standard granularities such as `medium` or `dense`, a single custom CPM bucket object or an array of custom CPM bucket objects | object, arary or string
 `DFP_VIDEO_AD_TYPE` | Set to true to create video ad units and creatives | boolean
 `DFP_VAST_REDIRECT_URL` | The redirect URL to use for video ad creatives (only used if `DFP_VIDEO_AD_TYPE` is set to True) | string
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Setting | Description | Type
 `DFP_TARGETED_PLACEMENT_NAMES` | The names of GAM placements the line items should target | array of strings
 `DFP_PLACEMENT_SIZES` | The creative sizes for the targeted placements | array of objects (e.g., `[{'width': '728', 'height': '90'}]`)
 `PREBID_BIDDER_CODE` | The value of [`hb_bidder`](http://prebid.org/dev-docs/publisher-api-reference.html#module_pbjs.bidderSettings) for this partner | string
-`PREBID_PRICE_BUCKETS` | The [price granularity](https://docs.prebid.org/dev-docs/publisher-api-reference/setConfig.html#setConfig-Price-Granularity); used to set `hb_pb` for each line item.  Can use Prebid standard granularities such as `medium` or `dense`, a single custom CPM bucket object or an array of custom CPM bucket objects | object, arary or string
+`PREBID_PRICE_BUCKETS` | The [price granularity](https://docs.prebid.org/dev-docs/publisher-api-reference/setConfig.html#setConfig-Price-Granularity); used to set `hb_pb` for each line item.  Can use Prebid standard granularities such as `medium` or `dense`, a single custom CPM bucket object or an array of custom CPM bucket objects | object, array or string
 `DFP_VIDEO_AD_TYPE` | Set to true to create video ad units and creatives | boolean
 `DFP_VAST_REDIRECT_URL` | The redirect URL to use for video ad creatives (only used if `DFP_VIDEO_AD_TYPE` is set to True) | string
 

--- a/settings.py
+++ b/settings.py
@@ -81,9 +81,9 @@ DFP_USE_EXISTING_ORDER_IF_EXISTS = False
 PREBID_BIDDER_CODE = None
 
 # Price buckets. This should match your Prebid settings for the partner.
-# Can be an a single bucket, an array of buckerts or string for standard Prebid
+# Can be an a single bucket, an array of buckets or string for standard Prebid
 #   price granularities such as 'medium', 'dense' or 'auto'
-# See: http://prebid.org/dev-docs/publisher-api-reference.html#module_pbjs.setPriceGranularity
+# See: https://docs.prebid.org/dev-docs/publisher-api-reference/setConfig.html#setConfig-Price-Granularity
 PREBID_PRICE_BUCKETS = {
   'precision': 2,
   'min' : 0,

--- a/settings.py
+++ b/settings.py
@@ -80,10 +80,10 @@ DFP_USE_EXISTING_ORDER_IF_EXISTS = False
 
 PREBID_BIDDER_CODE = None
 
-# Price buckets. This should match your Prebid settings for the partner. See:
-# http://prebid.org/dev-docs/publisher-api-reference.html#module_pbjs.setPriceGranularity
-# FIXME: this should be an array of buckets. See:
-# https://github.com/prebid/Prebid.js/blob/8fed3d7aaa814e67ca3efc103d7d306cab8c692c/src/cpmBucketManager.js
+# Price buckets. This should match your Prebid settings for the partner.
+# Can be an a single bucket, an array of buckerts or string for standard Prebid
+#   price granularities such as 'medium', 'dense' or 'auto'
+# See: http://prebid.org/dev-docs/publisher-api-reference.html#module_pbjs.setPriceGranularity
 PREBID_PRICE_BUCKETS = {
   'precision': 2,
   'min' : 0,

--- a/tasks/price_utils.py
+++ b/tasks/price_utils.py
@@ -37,7 +37,7 @@ def num_to_str(num, precision=2):
   Returns:
     a string
   """
-  return '%.{0}f'.format(str(precision)) % num 
+  return '%.{0}f'.format(str(precision)) % num
 
 def get_prices_array(price_bucket):
   """
@@ -48,7 +48,7 @@ def get_prices_array(price_bucket):
     price_bucket (object): the price bucket configuration
   Returns:
     an array of integers: every price bucket cutoff from:
-      int(round(price_bucket['min'] * 10**6, precision)) to 
+      int(round(price_bucket['min'] * 10**6, precision)) to
       int(round(price_bucket['max'] * 10**6, precision))
   """
   start_cpm = price_bucket['min'] if price_bucket['min'] >=0 else 0.00
@@ -65,7 +65,7 @@ def get_prices_array(price_bucket):
   while current_cpm_micro_amount <= end_cpm_micro_amount:
     prices.append(current_cpm_micro_amount)
     current_cpm_micro_amount += increment_micro_amount
-    
+
   return prices
 
 def get_prices_summary_string(prices_array, precision=2):
@@ -94,3 +94,68 @@ def get_prices_summary_string(prices_array, precision=2):
       )
 
   return summary
+
+prebid_bucketing_schemes = {
+    "low": [{
+        'precision': 2,
+        'min' : 0,
+        'max' : 5,
+        'increment': 0.50,
+    }],
+    "medium": [{
+        'precision': 2,
+        'min' : 0,
+        'max' : 20,
+        'increment': 0.10,
+    }],
+    #  High will try to create too many line items at once resulting in an error
+    #"high": [{
+    #    'precision': 2,
+    #    'min' : 0,
+    #    'max' : 20,
+    #    'increment': 0.01,
+    #}],
+    "auto": [
+        {
+        'precision': 2,
+        'min' : 0,
+        'max' : 3,
+        'increment': 0.05,
+        },
+        {
+          'precision': 2,
+          'min' : 3,
+          'max' : 8,
+          'increment': 0.05,
+        },
+        {
+          'precision': 2,
+          'min' : 8,
+          'max' : 20,
+          'increment': 0.50,
+        }],
+    "dense": [{
+        'precision': 2,
+        'min' : 0,
+        'max' : 3,
+        'increment': 0.01
+        },
+        {
+        'precision': 2,
+        'min' : 3,
+        'max' : 8,
+        'increment': 0.05,
+        },
+        {
+        'precision': 2,
+        'min' : 8,
+        'max' : 20,
+        'increment': 0.50,
+        }]
+}
+
+def get_prebid_standard_bucketing(bucketing_scheme):
+    if bucketing_scheme in prebid_bucketing_schemes:
+        return prebid_bucketing_schemes[bucketing_scheme]
+    else:
+        return None

--- a/tests/test_add_new_prebid_partner.py
+++ b/tests/test_add_new_prebid_partner.py
@@ -189,7 +189,7 @@ class AddNewPrebidPartnerTests(TestCase):
   @patch('tasks.add_new_prebid_partner.input', return_value='y')
   def test_prebid_medium_price_bucket_granularity(self, mock_input, mock_setup_partners, mock_dfp_client):
     """
-    Sets prices buckets correctly based on prebid auto granularity
+    Sets prices buckets correctly based on prebid medium granularity
     """
     settings.PREBID_PRICE_BUCKETS="medium"
 

--- a/tests/test_add_new_prebid_partner.py
+++ b/tests/test_add_new_prebid_partner.py
@@ -185,6 +185,75 @@ class AddNewPrebidPartnerTests(TestCase):
     tasks.add_new_prebid_partner.main()
     mock_setup_partners.assert_called_once()
 
+  @patch('tasks.add_new_prebid_partner.setup_partner')
+  @patch('tasks.add_new_prebid_partner.input', return_value='y')
+  def test_prebid_medium_price_bucket_granularity(self, mock_input, mock_setup_partners, mock_dfp_client):
+    """
+    Sets prices buckets correctly based on prebid auto granularity
+    """
+    settings.PREBID_PRICE_BUCKETS="medium"
+
+    tasks.add_new_prebid_partner.main()
+    args, kwargs = mock_setup_partners.call_args
+    self.assertEqual(len(args[7]), 201)
+    self.assertEqual(args[7][100], 10000000)
+    self.assertEqual(args[7][101], 10100000)
+    self.assertEqual(args[7][-1], 20000000)
+
+  @patch('tasks.add_new_prebid_partner.setup_partner')
+  @patch('tasks.add_new_prebid_partner.input', return_value='y')
+  def test_prebid_auto_price_bucket_granularity(self, mock_input, mock_setup_partners, mock_dfp_client):
+    """
+    Sets prices buckets correctly based on prebid auto granularity
+    """
+    settings.PREBID_PRICE_BUCKETS="auto"
+
+    tasks.add_new_prebid_partner.main()
+    args, kwargs = mock_setup_partners.call_args
+    self.assertEqual(len(args[7]), 185)
+    self.assertEqual(args[7][100], 5000000)
+    self.assertEqual(args[7][-1], 20000000)
+
+  @patch('tasks.add_new_prebid_partner.setup_partner')
+  @patch('tasks.add_new_prebid_partner.input', return_value='y')
+  def test_prebid_dense_price_bucket_granularity(self, mock_input, mock_setup_partners, mock_dfp_client):
+    """
+    Sets prices buckets correctly based on prebid dense granularity
+    """
+    settings.PREBID_PRICE_BUCKETS="dense"
+
+    tasks.add_new_prebid_partner.main()
+    args, kwargs = mock_setup_partners.call_args
+    self.assertEqual(len(args[7]), 425)
+    self.assertEqual(args[7][100], 1000000)
+    self.assertEqual(args[7][-1], 20000000)
+
+  @patch('tasks.add_new_prebid_partner.setup_partner')
+  @patch('tasks.add_new_prebid_partner.input', return_value='y')
+  def test_price_bucket_array(self, mock_input, mock_setup_partners, mock_dfp_client):
+    """
+    Sets prices buckets correctly when passing an array of buckets
+    """
+    settings.PREBID_PRICE_BUCKETS=[ {
+      'precision': 2,
+      'min' : 0,
+      'max' : 1,
+      'increment': 0.01,
+    },
+    {
+      'precision': 2,
+      'min' : 1,
+      'max' : 2,
+      'increment': 0.10,
+    }]
+
+    tasks.add_new_prebid_partner.main()
+    args, kwargs = mock_setup_partners.call_args
+    self.assertEqual(len(args[7]), 111)
+    self.assertEqual(args[7][50], 500000)
+    self.assertEqual(args[7][105], 1500000)
+    self.assertEqual(args[7][-1], 2000000)
+
   @patch('settings.DFP_NUM_CREATIVES_PER_LINE_ITEM', 5, create=True)
   @patch('tasks.add_new_prebid_partner.setup_partner')
   @patch('tasks.add_new_prebid_partner.input', return_value='y')


### PR DESCRIPTION
Update to PR #104 - Adding tests and README changes

Address Issue #27 Auto / Dense price granularity

Adds supports for an array of price buckets as well as standard Prebid price granularities: auto, dense, medium, low